### PR TITLE
Restore bindings for brand changes view model

### DIFF
--- a/DromHub/Services/BrandAuditService.cs
+++ b/DromHub/Services/BrandAuditService.cs
@@ -1,63 +1,257 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using DromHub.Data;
+using DromHub.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace DromHub.Services
 {
-    public enum AuditActionFilter { All, Insert, Update, Delete }
+    /// <summary>
+    /// Определяет срез аудита по типу операции, когда требуется сузить выдачу лога изменений брендов.
+    /// Используется UI для фильтрации записей, обеспечивая соответствие символам триггера (<c>I</c>, <c>U</c>, <c>D</c>).
+    /// Значения синхронизированы со структурой таблицы <c>brand_audit_log</c>, поэтому изменение требует обновления триггера.
+    /// </summary>
+    /// <remarks>
+    /// Потокобезопасность: перечисление неизменно и потокобезопасно.
+    /// Побочные эффекты: отсутствуют.
+    /// См. также: <see cref="BrandAuditService"/>.
+    /// </remarks>
+    public enum AuditActionFilter
+    {
+        /// <summary>
+        /// Возвращает все события аудита без дополнительной фильтрации по типу действия.
+        /// Подходит для стартового отображения истории изменений.
+        /// </summary>
+        All,
 
+        /// <summary>
+        /// Ограничивает выборку событиями вставки (<c>I</c>), полезно при анализе появления новых брендов.
+        /// </summary>
+        Insert,
+
+        /// <summary>
+        /// Включает только обновления (<c>U</c>), помогая выявить правки атрибутов бренда.
+        /// </summary>
+        Update,
+
+        /// <summary>
+        /// Отбирает события удаления (<c>D</c>), что актуально при расследовании потери данных.
+        /// </summary>
+        Delete
+    }
+
+    /// <summary>
+    /// Инкапсулирует параметры фильтрации, поиска и пагинации для выборки записей аудита брендов.
+    /// Позволяет UI гибко настраивать запросы к сервису, избегая прямой работы с SQL.
+    /// Используйте при формировании запросов из диалогов настройки историй изменений.
+    /// </summary>
+    /// <remarks>
+    /// Потокобезопасность: класс мутабелен и не потокобезопасен; используйте в пределах одного UI-потока.
+    /// Побочные эффекты: отсутствуют.
+    /// Требования к nullability: допускает <see langword="null"/> для необязательных параметров.
+    /// </remarks>
     public sealed class BrandAuditFilter
     {
+        /// <summary>
+        /// Определяет идентификатор бренда, по которому нужно отфильтровать историю.
+        /// Значение <see cref="Guid.Empty"/> отключает фильтр.
+        /// </summary>
+        /// <value>GUID бренда; по умолчанию — <see cref="Guid.Empty"/>.</value>
         public Guid BrandId { get; set; }
+
+        /// <summary>
+        /// Задает нижнюю границу временного диапазона выборки.
+        /// Помогает отсеять устаревшие события и ускорить запрос.
+        /// </summary>
+        /// <value>Дата и время в часовом поясе сервера; допускает <see langword="null"/>.</value>
         public DateTime? From { get; set; }
+
+        /// <summary>
+        /// Задает верхнюю границу временного диапазона выборки.
+        /// Используйте, чтобы просмотреть историю до конкретного момента.
+        /// </summary>
+        /// <value>Дата и время в часовом поясе сервера; допускает <see langword="null"/>.</value>
         public DateTime? To { get; set; }
+
+        /// <summary>
+        /// Определяет, какие типы действий аудита включать в выдачу.
+        /// </summary>
+        /// <value>Значение перечисления <see cref="AuditActionFilter"/>; по умолчанию — <see cref="AuditActionFilter.All"/>.</value>
         public AuditActionFilter Action { get; set; } = AuditActionFilter.All;
+
+        /// <summary>
+        /// Подстрока для поиска по текстовому представлению данных аудита.
+        /// Позволяет быстро находить конкретные изменения.
+        /// </summary>
+        /// <value>Чувствительность к регистру зависит от функции <c>ILIKE</c>; допускает <see langword="null"/>.</value>
         public string? Search { get; set; }
+
+        /// <summary>
+        /// Определяет, следует ли возвращать только записи с непустым списком измененных полей.
+        /// Помогает скрыть технические обновления без фактических изменений.
+        /// </summary>
+        /// <value><see langword="true"/>, если нужно оставить только события с изменениями.</value>
         public bool OnlyChangedFields { get; set; }
+
+        /// <summary>
+        /// Индекс страницы для пагинации; отрицательные значения нормализуются сервисом до нуля.
+        /// </summary>
+        /// <value>Номер страницы, начиная с нуля.</value>
         public int PageIndex { get; set; } = 0;
+
+        /// <summary>
+        /// Желаемый размер страницы; сервис ограничивает значение диапазоном [1; 200].
+        /// </summary>
+        /// <value>Количество строк на страницу; по умолчанию — 20.</value>
         public int PageSize { get; set; } = 20;
     }
 
     /// <summary>
-    /// Модель строки для UI (без with/foreach-assign, с display-полями).
+    /// Представляет строку аудита бренда, подготовленную для потребления XAML-интерфейсом.
+    /// Инкапсулирует исходные данные и производные текстовые представления, уменьшая нагрузку на слой представления.
+    /// Обеспечивает единообразное отображение истории изменений в разных разделах приложения.
     /// </summary>
+    /// <remarks>
+    /// Потокобезопасность: объект иммутабелен после инициализации; допускает совместное чтение.
+    /// Побочные эффекты: отсутствуют.
+    /// </remarks>
     public sealed class BrandAuditRow
     {
+        /// <summary>
+        /// Идентификатор события аудита, совпадает с <c>event_id</c> в таблице.
+        /// </summary>
+        /// <value>GUID события.</value>
         public Guid Id { get; init; }
+
+        /// <summary>
+        /// Отметка времени события, используемая для сортировки и отображения.
+        /// </summary>
+        /// <value>Дата и время в UTC.</value>
         public DateTime Ts { get; init; }
-        public string Action { get; init; } = "";
-        public string User { get; init; } = "";
-        public string Table { get; init; } = "";
+
+        /// <summary>
+        /// Код действия аудита (<c>I</c>, <c>U</c>, <c>D</c>), применяемый для визуализации и фильтрации.
+        /// </summary>
+        /// <value>Строка длиной 1; по умолчанию — пустая строка.</value>
+        public string Action { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Имя пользователя или роли, выполнившей изменение.
+        /// </summary>
+        /// <value>Человеко-читаемое имя; по умолчанию — пустая строка.</value>
+        public string User { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Имя таблицы, к которой относится событие аудита.
+        /// </summary>
+        /// <value>Название таблицы; по умолчанию — пустая строка.</value>
+        public string Table { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Идентификатор бренда, который затронуто изменением.
+        /// </summary>
+        /// <value>GUID бренда или <see langword="null"/>.</value>
         public Guid? BrandId { get; init; }
+
+        /// <summary>
+        /// JSON-снимок состояния сущности до изменения.
+        /// </summary>
+        /// <value>Строка JSON или <see langword="null"/>.</value>
         public string? OldJson { get; init; }
+
+        /// <summary>
+        /// JSON-снимок состояния сущности после изменения.
+        /// </summary>
+        /// <value>Строка JSON или <see langword="null"/>.</value>
         public string? NewJson { get; init; }
+
+        /// <summary>
+        /// Список названий столбцов, которые фактически изменились.
+        /// </summary>
+        /// <value>Набор имен; пуст, если данные не предоставлены триггером.</value>
         public IReadOnlyList<string> ChangedColumns { get; init; } = Array.Empty<string>();
 
-        // ---- DISPLAY ДЛЯ XAML (вместо StringFormat в Binding) ----
+        /// <summary>
+        /// Готовое представление даты и времени для XAML.
+        /// </summary>
+        /// <value>Строка формата «ДД.ММ.ГГГГ ЧЧ:ММ».</value>
         public string TsDisplay => Ts.ToString("dd.MM.yyyy HH:mm");
-        public string ActionDisplay => Action.ToUpperInvariant();
+
+        /// <summary>
+        /// Отображаемая форма кода действия.
+        /// </summary>
+        /// <value>Заглавная буква или «—» при отсутствии значения.</value>
+        public string ActionDisplay => string.IsNullOrEmpty(Action) ? "—" : Action.ToUpperInvariant();
+
+        /// <summary>
+        /// Текстовое представление списка измененных столбцов.
+        /// </summary>
+        /// <value>Строка с именами через запятую или «—».</value>
         public string ChangedColumnsJoined => ChangedColumns.Count == 0 ? "—" : string.Join(", ", ChangedColumns);
+
+        /// <summary>
+        /// Отображаемое значение автора изменения.
+        /// </summary>
+        /// <value>Имя пользователя или «—».</value>
         public string UserDisplay => string.IsNullOrWhiteSpace(User) ? "—" : User;
+
+        /// <summary>
+        /// Отображаемое название таблицы.
+        /// </summary>
+        /// <value>Имя таблицы или «—».</value>
         public string TableDisplay => string.IsNullOrWhiteSpace(Table) ? "—" : Table;
     }
 
+    /// <summary>
+    /// Реализует чтение лога аудита брендов с учетом фильтров и пагинации.
+    /// Снимает необходимость в прямых SQL-запросах, предоставляя готовую модель данных для UI.
+    /// Учитывает специфику триггера <c>trg_brand_audit</c> и структуру таблицы <c>brand_audit_log</c>.
+    /// </summary>
+    /// <remarks>
+    /// Потокобезопасность: экземпляр потокобезопасен при условии потокобезопасной реализации <see cref="IDbContextFactory{TContext}"/>.
+    /// Побочные эффекты: выполняет операции чтения из БД PostgreSQL.
+    /// </remarks>
     public sealed class BrandAuditService
     {
+        /// <summary>
+        /// Сохраняет фабрику контекста данных для создания подключений по требованию.
+        /// </summary>
         private readonly IDbContextFactory<ApplicationDbContext> _dbFactory;
 
+        /// <summary>
+        /// Инициализирует сервис аудита с фабрикой контекста данных.
+        /// </summary>
+        /// <param name="dbFactory">Фабрика, создающая экземпляры <see cref="ApplicationDbContext"/> по требованию.</param>
         public BrandAuditService(IDbContextFactory<ApplicationDbContext> dbFactory)
         {
             _dbFactory = dbFactory;
         }
 
         /// <summary>
-        /// Возвращает (строки, всего) с применёнными фильтрами/сортировкой/пагинацией.
+        /// Загружает записи аудита бренда, применяя фильтры, поиск и пагинацию.
+        /// Сопоставляет символьные коды действий триггера с пользовательскими фильтрами.
         /// </summary>
+        /// <param name="filter">Параметры фильтрации и пагинации; допускают пустые значения.</param>
+        /// <param name="ct">Токен отмены операции. При отмене выбрасывается <see cref="OperationCanceledException"/>.</param>
+        /// <returns>Кортеж, содержащий список строк для UI и общее количество записей.</returns>
+        /// <exception cref="InvalidOperationException">Контекст данных не смог подключиться к таблице аудита.</exception>
+        /// <exception cref="OperationCanceledException">Отмена операции пользователем или инфраструктурой через <paramref name="ct"/>.</exception>
+        /// <remarks>
+        /// Предусловия: фабрика контекста должна быть сконфигурирована и доступна.
+        /// Постусловия: контекст корректно освобожден (используется <see cref="IAsyncDisposable"/>).
+        /// Потокобезопасность: метод безопасен для параллельного вызова; каждый вызов создает новый контекст.
+        /// Побочные эффекты: выполняет один запрос COUNT и один запрос SELECT.
+        /// Сложность: O(n) относительно размера страницы.
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// var filter = new BrandAuditFilter { BrandId = brandId, OnlyChangedFields = true };
+        /// var (rows, total) = await auditService.GetAsync(filter, cancellationToken);
+        /// </code>
+        /// </example>
         public async Task<(IReadOnlyList<BrandAuditRow> Rows, int Total)> GetAsync(
             BrandAuditFilter filter,
             CancellationToken ct = default)
@@ -65,29 +259,25 @@ namespace DromHub.Services
             await using var db = await _dbFactory.CreateDbContextAsync(ct);
 
             // Таблица аудита: brand_audit_log (создана SQL-триггером)
-            // Столбцы предполагаются: id, ts, action, username, table_name, brand_id, old_data (jsonb), new_data (jsonb), changed_columns (text[])
-            var q = db.Set<BrandAuditLogRow>().AsNoTracking().AsQueryable();
+            var q = db.BrandAuditLogs.AsNoTracking().AsQueryable();
 
             // ---- FILTERS ----
             if (filter.BrandId != Guid.Empty)
                 q = q.Where(x => x.BrandId == filter.BrandId);
 
             if (filter.From.HasValue)
-                q = q.Where(x => x.Ts >= filter.From.Value);
+                q = q.Where(x => x.EventTime >= filter.From.Value);
 
             if (filter.To.HasValue)
-                q = q.Where(x => x.Ts <= filter.To.Value);
+                q = q.Where(x => x.EventTime <= filter.To.Value);
 
             if (filter.Action != AuditActionFilter.All)
             {
-                var act = filter.Action switch
+                var act = ToActionCode(filter.Action);
+                if (act.HasValue)
                 {
-                    AuditActionFilter.Insert => "INSERT",
-                    AuditActionFilter.Update => "UPDATE",
-                    AuditActionFilter.Delete => "DELETE",
-                    _ => null
-                };
-                if (act != null) q = q.Where(x => x.Action == act);
+                    q = q.Where(x => x.Action == act.Value);
+                }
             }
 
             if (!string.IsNullOrWhiteSpace(filter.Search))
@@ -95,17 +285,17 @@ namespace DromHub.Services
                 var s = filter.Search.Trim();
                 // простейший поиск по JSON: text-представление
                 q = q.Where(x =>
-                    (x.OldData != null && EF.Functions.ILike(x.OldDataText!, $"%{s}%")) ||
-                    (x.NewData != null && EF.Functions.ILike(x.NewDataText!, $"%{s}%")));
+                    (x.OldText != null && EF.Functions.ILike(x.OldText!, $"%{s}%")) ||
+                    (x.NewText != null && EF.Functions.ILike(x.NewText!, $"%{s}%")));
             }
 
             if (filter.OnlyChangedFields)
             {
-                q = q.Where(x => x.Action == "UPDATE" && x.ChangedColumns != null && x.ChangedColumns.Length > 0);
+                q = q.Where(x => x.Action == 'U' && x.ChangedColumns != null && x.ChangedColumns.Length > 0);
             }
 
             // ---- ORDER ----
-            q = q.OrderByDescending(x => x.Ts);
+            q = q.OrderByDescending(x => x.EventTime);
 
             // ---- TOTAL ----
             var total = await q.CountAsync(ct);
@@ -123,14 +313,14 @@ namespace DromHub.Services
             {
                 rows.Add(new BrandAuditRow
                 {
-                    Id = a.Id,
-                    Ts = a.Ts,
-                    Action = a.Action ?? "",
-                    User = a.UserName ?? "",
-                    Table = a.TableName ?? "",
+                    Id = a.EventId,
+                    Ts = a.EventTime.UtcDateTime,
+                    Action = MapActionDisplay(a.Action),
+                    User = a.Actor ?? string.Empty,
+                    Table = "brands",
                     BrandId = a.BrandId,
-                    OldJson = a.OldDataText,
-                    NewJson = a.NewDataText,
+                    OldJson = a.OldData,
+                    NewJson = a.NewData,
                     ChangedColumns = a.ChangedColumns ?? Array.Empty<string>()
                 });
             }
@@ -139,26 +329,47 @@ namespace DromHub.Services
         }
 
         /// <summary>
-        /// Внутренняя EF-модель чтения из brand_audit_log (только для сервиса).
+        /// Преобразует выбранное значение фильтра действий в код, используемый триггером аудита.
         /// </summary>
-        private sealed class BrandAuditLogRow
+        /// <param name="filter">Значение фильтра действий.</param>
+        /// <returns>Символ действия или <see langword="null"/>, если фильтр не требуется.</returns>
+        /// <remarks>
+        /// Потокобезопасность: статический метод, не использующий состояние.
+        /// Побочные эффекты: отсутствуют.
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// var code = ToActionCode(AuditActionFilter.Update); // вернет 'U'
+        /// </code>
+        /// </example>
+        private static char? ToActionCode(AuditActionFilter filter) => filter switch
         {
-            public Guid Id { get; set; }
-            public DateTime Ts { get; set; }
-            public string? Action { get; set; }
-            public string? UserName { get; set; }
-            public string? TableName { get; set; }
-            public Guid? BrandId { get; set; }
+            AuditActionFilter.Insert => 'I',
+            AuditActionFilter.Update => 'U',
+            AuditActionFilter.Delete => 'D',
+            _ => null
+        };
 
-            // jsonb в БД мапим на string? + теневые-свойства для поиска
-            public string? OldDataText { get; set; }
-            public string? NewDataText { get; set; }
-
-            public string[]? ChangedColumns { get; set; }
-
-            // Эти поля пометим как не сопоставленные EF, если используете Fluent API
-            public object? OldData { get; set; }
-            public object? NewData { get; set; }
-        }
+        /// <summary>
+        /// Конвертирует код действия из таблицы аудита в строковое представление для UI.
+        /// </summary>
+        /// <param name="action">Код действия (<c>I</c>, <c>U</c>, <c>D</c>).</param>
+        /// <returns>Однобуквенная строка или пустая строка для неизвестных значений.</returns>
+        /// <remarks>
+        /// Потокобезопасность: статический метод без состояния.
+        /// Побочные эффекты: отсутствуют.
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// var display = MapActionDisplay('I'); // вернет "I"
+        /// </code>
+        /// </example>
+        private static string MapActionDisplay(char action) => action switch
+        {
+            'I' => "I",
+            'U' => "U",
+            'D' => "D",
+            _ => string.Empty
+        };
     }
 }

--- a/DromHub/ViewModels/BrandChangesPage.cs
+++ b/DromHub/ViewModels/BrandChangesPage.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Drawing.Printing;
+using System.Globalization;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -9,92 +10,619 @@ using DromHub.Services;
 
 namespace DromHub.ViewModels;
 
-public partial class BrandChangesViewModel : ObservableObject
+/// <summary>
+/// <para>Управляет состоянием экрана истории изменений бренда, объединяя фильтры, пагинацию и команды обновления.</para>
+/// <para>Используется страницей администратора для расследования правок и аудита, обращаясь к <see cref="BrandAuditService"/> для получения данных.</para>
+/// <para>Не выполняет запись и кеширование; каждый пересчет фильтра инициирует новое чтение журнала.</para>
+/// </summary>
+/// <remarks>
+/// Потокобезопасность: экземпляр предназначен для использования только в UI-потоке и не потокобезопасен.
+/// Побочные эффекты: выполняет операции чтения через <see cref="BrandAuditService"/> и обновляет коллекции UI.
+/// Сложность типичных операций: O(n) относительно размера текущей страницы при загрузке.
+/// См. также: <see cref="BrandAuditService"/>.
+/// </remarks>
+public sealed partial class BrandChangesViewModel : ObservableObject
 {
+    /// <summary>
+    /// Сохраняет ссылку на сервис аудита для построения выдачи журнала изменений.
+    /// </summary>
     private readonly BrandAuditService _service;
 
+    /// <summary>
+    /// Инкапсулирует команду обновления данных, чтобы повторно использовать ее как источник <see cref="RefreshCommand"/>.
+    /// </summary>
+    private readonly AsyncRelayCommand _loadCommand;
+
+    /// <summary>
+    /// Инкапсулирует команду перехода на следующую страницу, чтобы управлять жизненным циклом CanExecute.
+    /// </summary>
+    private readonly AsyncRelayCommand _nextPageCommand;
+
+    /// <summary>
+    /// Инкапсулирует команду перехода на предыдущую страницу, обеспечивая централизованное управление доступностью.
+    /// </summary>
+    private readonly AsyncRelayCommand _prevPageCommand;
+
+    /// <summary>
+    /// Хранит идентификатор бренда, историю которого просматривает пользователь.
+    /// </summary>
+    private Guid _brandId;
+
+    /// <summary>
+    /// Запоминает выбранную пользователем начальную дату фильтрации.
+    /// </summary>
+    private DateTimeOffset? _fromDate;
+
+    /// <summary>
+    /// Запоминает выбранную пользователем конечную дату фильтрации.
+    /// </summary>
+    private DateTimeOffset? _toDate;
+
+    /// <summary>
+    /// Хранит текущее значение фильтра по типу действия аудита.
+    /// </summary>
+    private AuditActionFilter _selectedAction = AuditActionFilter.All;
+
+    /// <summary>
+    /// Показывает, нужно ли ограничивать выдачу событиями с реальными изменениями полей.
+    /// </summary>
+    private bool _onlyChangedFields;
+
+    /// <summary>
+    /// Содержит поисковую подстроку, применяемую к JSON-представлениям записей.
+    /// </summary>
+    private string? _search;
+
+    /// <summary>
+    /// Указывает, сколько строк отображать на странице.
+    /// </summary>
+    private int _pageSize = 25;
+
+    /// <summary>
+    /// Фиксирует текущий индекс страницы для пагинации.
+    /// </summary>
+    private int _pageIndex;
+
+    /// <summary>
+    /// Содержит общее количество записей, доступных при заданных фильтрах.
+    /// </summary>
+    private int _totalCount;
+
+    /// <summary>
+    /// Показывает, выполняется ли в настоящий момент загрузка данных.
+    /// </summary>
+    private bool _isBusy;
+
+    /// <summary>
+    /// Содержит текст ошибки, отображаемый пользователю при сбоях загрузки.
+    /// </summary>
+    private string? _errorMessage;
+
+    /// <summary>
+    /// Представляет информационную строку пагинации для отображения диапазона записей.
+    /// </summary>
+    private string _pageInfo = "Нет данных.";
+
+    /// <summary>
+    /// Фиксирует необходимость повторной загрузки после завершения текущей операции.
+    /// </summary>
+    private bool _pendingReload;
+
+    /// <summary>
+    /// Инициализирует модель представления зависимостью от <see cref="BrandAuditService"/> и настраивает команды.
+    /// </summary>
+    /// <param name="service">Сервис чтения лога аудита брендов; не допускает значение <see langword="null"/>.</param>
+    /// <exception cref="ArgumentNullException">Возникает, когда <paramref name="service"/> не предоставлен контейнером.</exception>
+    /// <remarks>
+    /// Предусловия: контейнер внедрения зависимостей должен предоставить корректный экземпляр сервиса.
+    /// Постусловия: коллекции и команды готовы к использованию страницей.
+    /// Побочные эффекты: заполняет списки параметров фильтров.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// var vm = new BrandChangesViewModel(service);
+    /// await vm.InitializeAsync(existingBrandId);
+    /// </code>
+    /// </example>
     public BrandChangesViewModel(BrandAuditService service)
     {
-        _service = service;
-        Items = new ObservableCollection<BrandAuditRow>();
-        PageSizes = new ObservableCollection<int> { 10, 25, 50, 100 };
+        _service = service ?? throw new ArgumentNullException(nameof(service));
 
-        LoadCommand = new AsyncRelayCommand(LoadAsync);
-        NextPageCommand = new AsyncRelayCommand(NextPageAsync, () => (PageIndex + 1) * PageSize < TotalCount);
-        PrevPageCommand = new AsyncRelayCommand(PrevPageAsync, () => PageIndex > 0);
+        Rows = new ObservableCollection<BrandAuditRow>();
+        PageSizes = new ObservableCollection<int>(new[] { 10, 25, 50, 100 });
+        ActionItems = new ReadOnlyCollection<AuditActionFilter>(new[]
+        {
+            AuditActionFilter.All,
+            AuditActionFilter.Insert,
+            AuditActionFilter.Update,
+            AuditActionFilter.Delete
+        });
+
+        _loadCommand = new AsyncRelayCommand(LoadInternalAsync, () => !IsBusy);
+        _nextPageCommand = new AsyncRelayCommand(NextPageInternalAsync, CanGoNext);
+        _prevPageCommand = new AsyncRelayCommand(PrevPageInternalAsync, CanGoPrevious);
     }
 
-    // Входной бренд
-    [ObservableProperty] private Guid brandId;
+    /// <summary>
+    /// Возвращает коллекцию значений фильтра по действию, доступную элементу ComboBox.
+    /// </summary>
+    /// <value>Набор значений перечисления <see cref="AuditActionFilter"/> в фиксированном порядке.</value>
+    /// <remarks>
+    /// Коллекция иммутабельна и переиспользуется привязками.
+    /// </remarks>
+    public IReadOnlyList<AuditActionFilter> ActionItems { get; }
 
-    // Фильтры
-    [ObservableProperty] private DateTimeOffset? fromDate = null;
-    [ObservableProperty] private DateTimeOffset? toDate = null;
-    [ObservableProperty] private AuditActionFilter action = AuditActionFilter.All;
-    [ObservableProperty] private bool onlyChangedFields = false;
-    [ObservableProperty] private string? search;
-
-
-    // Пагинация
+    /// <summary>
+    /// Возвращает коллекцию доступных размеров страницы для выбора пользователем.
+    /// </summary>
+    /// <value>Редактируемая коллекция целых чисел; значения выражены в количестве строк.</value>
+    /// <remarks>
+    /// Изменение содержимого при необходимости отразится в UI автоматически.
+    /// </remarks>
     public ObservableCollection<int> PageSizes { get; }
-    [ObservableProperty] private int pageSize = 25;
-    [ObservableProperty] private int pageIndex = 0;
-    [ObservableProperty] private int totalCount = 0;
 
-    // UI
-    [ObservableProperty] private bool isBusy;
-    [ObservableProperty] private string? errorMessage;
-    public ObservableCollection<BrandAuditRow> Items { get; }
+    /// <summary>
+    /// Предоставляет последовательность строк аудита, привязанную к элементу списка.
+    /// </summary>
+    /// <value>Наблюдаемая коллекция, синхронизированная с результатами <see cref="BrandAuditService"/>.</value>
+    /// <remarks>
+    /// Коллекция очищается и заполняется заново при каждой загрузке.
+    /// </remarks>
+    public ObservableCollection<BrandAuditRow> Rows { get; }
 
-    public IAsyncRelayCommand LoadCommand { get; }
-    public IAsyncRelayCommand NextPageCommand { get; }
-    public IAsyncRelayCommand PrevPageCommand { get; }
+    /// <summary>
+    /// Представляет команду принудительного обновления данных журнала.
+    /// </summary>
+    /// <value>Экземпляр <see cref="IAsyncRelayCommand"/>, выполняющий запрос к сервису аудита.</value>
+    /// <remarks>
+    /// Команда отключена во время выполнения асинхронной загрузки.
+    /// </remarks>
+    public IAsyncRelayCommand RefreshCommand => _loadCommand;
 
-    partial void OnPageSizeChanged(int value)
+    /// <summary>
+    /// Представляет команду перехода на следующую страницу аудита.
+    /// </summary>
+    /// <value>Экземпляр <see cref="IAsyncRelayCommand"/>, изменяющий <see cref="PageIndex"/> и выполняющий повторную загрузку.</value>
+    /// <remarks>
+    /// Команда недоступна, когда текущая страница отображает последний диапазон записей.
+    /// </remarks>
+    public IAsyncRelayCommand NextPageCommand => _nextPageCommand;
+
+    /// <summary>
+    /// Представляет команду возврата на предыдущую страницу аудита.
+    /// </summary>
+    /// <value>Экземпляр <see cref="IAsyncRelayCommand"/>, уменьшающий <see cref="PageIndex"/>.</value>
+    /// <remarks>
+    /// Команда недоступна на первой странице.
+    /// </remarks>
+    public IAsyncRelayCommand PrevPageCommand => _prevPageCommand;
+
+    /// <summary>
+    /// Возвращает или задает идентификатор бренда, журнал изменений которого отображается.
+    /// </summary>
+    /// <value>GUID бренда; значение по умолчанию — <see cref="Guid.Empty"/>, что означает отсутствие выбранного бренда.</value>
+    /// <remarks>
+    /// Изменение свойства очищает текущие данные и требует повторной инициализации через <see cref="InitializeAsync(Guid)"/>.
+    /// </remarks>
+    public Guid BrandId
     {
-        PageIndex = 0;
-        _ = LoadAsync();
+        get => _brandId;
+        private set => SetProperty(ref _brandId, value);
     }
 
-    partial void OnActionChanged(AuditActionFilter value) => _ = LoadAsync();
+    /// <summary>
+    /// Возвращает или задает начальную дату диапазона фильтрации.
+    /// </summary>
+    /// <value>Дата в локальной временной зоне; допускает <see langword="null"/> для отключения фильтра.</value>
+    /// <remarks>
+    /// Изменение автоматически перезагружает первую страницу журнала.
+    /// </remarks>
+    public DateTimeOffset? FromDate
+    {
+        get => _fromDate;
+        set
+        {
+            if (SetProperty(ref _fromDate, value))
+            {
+                ScheduleReload(resetPage: true);
+            }
+        }
+    }
 
+    /// <summary>
+    /// Возвращает или задает конечную дату диапазона фильтрации.
+    /// </summary>
+    /// <value>Дата в локальной временной зоне; допускает <see langword="null"/>.</value>
+    /// <remarks>
+    /// Изменение свойства вызывает перезагрузку с возвратом на первую страницу.
+    /// </remarks>
+    public DateTimeOffset? ToDate
+    {
+        get => _toDate;
+        set
+        {
+            if (SetProperty(ref _toDate, value))
+            {
+                ScheduleReload(resetPage: true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Возвращает или задает выбранный тип действия аудита.
+    /// </summary>
+    /// <value>Одно из значений <see cref="AuditActionFilter"/>; по умолчанию — <see cref="AuditActionFilter.All"/>.</value>
+    /// <remarks>
+    /// При изменении фильтра выполняется повторная загрузка первой страницы.
+    /// </remarks>
+    public AuditActionFilter SelectedAction
+    {
+        get => _selectedAction;
+        set
+        {
+            if (SetProperty(ref _selectedAction, value))
+            {
+                ScheduleReload(resetPage: true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Возвращает или задает признак «только записи с измененными полями».
+    /// </summary>
+    /// <value><see langword="true"/>, если нужно показывать только события с заполненным списком столбцов.</value>
+    /// <remarks>
+    /// Фильтр применим только к событиям обновления; сервис обрабатывает остальное.
+    /// </remarks>
+    public bool OnlyChangedFields
+    {
+        get => _onlyChangedFields;
+        set
+        {
+            if (SetProperty(ref _onlyChangedFields, value))
+            {
+                ScheduleReload(resetPage: true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Возвращает или задает поисковую строку для фильтрации данных.
+    /// </summary>
+    /// <value>Подстрока без ограничений по длине; пустая строка приравнивается к отсутствию фильтра.</value>
+    /// <remarks>
+    /// Поиск выполняется по текстовому представлению JSON-столбцов.
+    /// </remarks>
+    public string? Search
+    {
+        get => _search;
+        set
+        {
+            if (SetProperty(ref _search, value))
+            {
+                ScheduleReload(resetPage: true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Возвращает или задает размер страницы для запросов аудита.
+    /// </summary>
+    /// <value>Положительное целое число; значение ограничивается сервисом диапазоном [1; 200].</value>
+    /// <remarks>
+    /// При изменении размера страница сбрасывается на начало и выполняется повторная загрузка.
+    /// </remarks>
+    public int PageSize
+    {
+        get => _pageSize;
+        set
+        {
+            if (SetProperty(ref _pageSize, value))
+            {
+                PageIndex = 0;
+                ScheduleReload(resetPage: false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Возвращает текущий индекс страницы.
+    /// </summary>
+    /// <value>Ненегативное целое число; по умолчанию — 0.</value>
+    /// <remarks>
+    /// Свойство изменяется только внутренними командами, обеспечивая согласованность пагинации.
+    /// </remarks>
+    public int PageIndex
+    {
+        get => _pageIndex;
+        private set
+        {
+            if (SetProperty(ref _pageIndex, value))
+            {
+                UpdatePaginationCommands();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Возвращает или задает общее количество записей, соответствующих текущим фильтрам.
+    /// </summary>
+    /// <value>Ненегативное целое число; значение 0 означает отсутствие данных.</value>
+    /// <remarks>
+    /// Обновляется после каждого обращения к сервису и влияет на команды пагинации.</remarks>
+    public int TotalCount
+    {
+        get => _totalCount;
+        private set
+        {
+            if (SetProperty(ref _totalCount, value))
+            {
+                UpdatePaginationCommands();
+                UpdatePageInfo();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Показывает, выполняется ли сейчас загрузка.
+    /// </summary>
+    /// <value><see langword="true"/>, когда модель занята; по умолчанию — <see langword="false"/>.</value>
+    /// <remarks>
+    /// Состояние влияет на доступность команды обновления.
+    /// </remarks>
+    public bool IsBusy
+    {
+        get => _isBusy;
+        private set
+        {
+            if (SetProperty(ref _isBusy, value))
+            {
+                _loadCommand.NotifyCanExecuteChanged();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Возвращает или задает текст ошибки для отображения пользователю.
+    /// </summary>
+    /// <value>Локализованное сообщение или <see langword="null"/>, если ошибок нет.</value>
+    /// <remarks>
+    /// Значение очищается перед каждой новой загрузкой.
+    /// </remarks>
+    public string? ErrorMessage
+    {
+        get => _errorMessage;
+        private set => SetProperty(ref _errorMessage, value);
+    }
+
+    /// <summary>
+    /// Возвращает строку с информацией о текущем диапазоне записей.
+    /// </summary>
+    /// <value>Текст, например «Показаны 1-25 из 120» или «Нет записей».</value>
+    /// <remarks>
+    /// Значение автоматически обновляется при изменении коллекции данных или счетчиков.
+    /// </remarks>
+    public string PageInfo
+    {
+        get => _pageInfo;
+        private set => SetProperty(ref _pageInfo, value);
+    }
+
+    /// <summary>
+    /// Выполняет первичную загрузку аудита для переданного бренда.
+    /// </summary>
+    /// <param name="brandId">Идентификатор бренда; не допускается <see cref="Guid.Empty"/>.</param>
+    /// <returns>Задача, завершающаяся после подготовки первой страницы журнала.</returns>
+    /// <exception cref="ArgumentException">Выбрасывается, когда <paramref name="brandId"/> равен <see cref="Guid.Empty"/>.</exception>
+    /// <remarks>
+    /// Предусловия: страница еще не инициализирована другим брендом.
+    /// Постусловия: установлены фильтры по умолчанию и загружены первые данные.
+    /// Побочные эффекты: выполняет обращение к базе данных через сервис.
+    /// </remarks>
+    /// <example>
+    /// <code>
+    /// await viewModel.InitializeAsync(brandId);
+    /// // Далее можно менять фильтры: viewModel.OnlyChangedFields = true;
+    /// </code>
+    /// </example>
     public async Task InitializeAsync(Guid brandId)
     {
+        if (brandId == Guid.Empty)
+        {
+            throw new ArgumentException("Идентификатор бренда не может быть пустым.", nameof(brandId));
+        }
+
         BrandId = brandId;
         PageIndex = 0;
-        await LoadAsync();
+        await _loadCommand.ExecuteAsync(null);
     }
 
-    private async Task LoadAsync()
+    /// <summary>
+    /// Строит объект фильтра и выполняет запрос сервиса аудита.
+    /// </summary>
+    /// <returns>Задача, завершающаяся после обновления коллекции <see cref="Rows"/>.</returns>
+    /// <remarks>
+    /// Предусловия: <see cref="BrandId"/> задан и не равен <see cref="Guid.Empty"/>.
+    /// Постусловия: <see cref="Rows"/>, <see cref="TotalCount"/> и <see cref="PageInfo"/> отражают актуальное состояние.
+    /// Побочные эффекты: выполняет чтение из БД и обновляет наблюдаемые коллекции.
+    /// Идемпотентность: повторные вызовы с неизменными фильтрами возвращают одинаковые данные.
+    /// </remarks>
+    private async Task LoadInternalAsync()
     {
-        DateTime? from = FromDate?.DateTime.Date;                         // начало дня (локально)
-        DateTime? to = ToDate?.DateTime.Date.AddDays(1).AddTicks(-1);   // конец дня
+        if (BrandId == Guid.Empty)
+        {
+            Rows.Clear();
+            TotalCount = 0;
+            PageInfo = "Бренд не выбран.";
+            return;
+        }
 
-        var filter = new BrandAuditFilter
+        if (IsBusy)
+        {
+            return;
+        }
+
+        IsBusy = true;
+        ErrorMessage = null;
+
+        try
+        {
+            var filter = BuildFilter();
+            var (rows, total) = await _service.GetAsync(filter);
+
+            Rows.Clear();
+            foreach (var row in rows)
+            {
+                Rows.Add(row);
+            }
+
+            TotalCount = total;
+        }
+        catch (OperationCanceledException)
+        {
+            ErrorMessage = "Загрузка отменена.";
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+        }
+        finally
+        {
+            IsBusy = false;
+
+            if (_pendingReload)
+            {
+                _pendingReload = false;
+                _ = _loadCommand.ExecuteAsync(null);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Создает объект фильтра на основе текущего состояния модели представления.
+    /// </summary>
+    /// <returns>Экземпляр <see cref="BrandAuditFilter"/> с заполненными параметрами.</returns>
+    /// <remarks>
+    /// Конвертирует даты в границы суток и очищает пустые строки поиска.
+    /// </remarks>
+    private BrandAuditFilter BuildFilter()
+    {
+        DateTime? from = FromDate?.Date;
+        DateTime? to = ToDate?.Date.AddDays(1).AddTicks(-1);
+        string? search = string.IsNullOrWhiteSpace(Search) ? null : Search.Trim();
+
+        return new BrandAuditFilter
         {
             BrandId = BrandId,
             From = from,
             To = to,
-            Action = Action,
-            Search = string.IsNullOrWhiteSpace(Search) ? null : Search,
+            Action = SelectedAction,
+            Search = search,
             OnlyChangedFields = OnlyChangedFields,
             PageIndex = PageIndex,
             PageSize = PageSize
         };
-
     }
 
-    private Task NextPageAsync()
+    /// <summary>
+    /// Вычисляет и сохраняет строку с диапазоном отображаемых записей.
+    /// </summary>
+    /// <remarks>
+    /// Использует текущие значения <see cref="PageIndex"/>, <see cref="PageSize"/> и размер коллекции <see cref="Rows"/>.
+    /// </remarks>
+    private void UpdatePageInfo()
     {
-        if ((PageIndex + 1) * PageSize >= TotalCount) return Task.CompletedTask;
+        if (TotalCount == 0 || Rows.Count == 0)
+        {
+            PageInfo = "Нет записей.";
+            return;
+        }
+
+        var start = PageIndex * PageSize + 1;
+        var end = Math.Min(TotalCount, start + Rows.Count - 1);
+        PageInfo = string.Format(CultureInfo.CurrentCulture, "Показаны {0}-{1} из {2}", start, end, TotalCount);
+    }
+
+    /// <summary>
+    /// Обновляет состояние доступности команд пагинации.
+    /// </summary>
+    /// <remarks>
+    /// Вызывается после изменения счетчиков и индексов.
+    /// </remarks>
+    private void UpdatePaginationCommands()
+    {
+        _nextPageCommand.NotifyCanExecuteChanged();
+        _prevPageCommand.NotifyCanExecuteChanged();
+    }
+
+    /// <summary>
+    /// Проверяет возможность перехода на следующую страницу.
+    /// </summary>
+    /// <returns><see langword="true"/>, если следующая страница содержит записи.</returns>
+    private bool CanGoNext() => (PageIndex + 1) * PageSize < TotalCount;
+
+    /// <summary>
+    /// Проверяет возможность возврата на предыдущую страницу.
+    /// </summary>
+    /// <returns><see langword="true"/>, если текущий индекс больше нуля.</returns>
+    private bool CanGoPrevious() => PageIndex > 0;
+
+    /// <summary>
+    /// Переходит на следующую страницу и инициирует загрузку данных.
+    /// </summary>
+    /// <returns>Задача, завершающаяся после обновления данных.</returns>
+    /// <remarks>
+    /// Игнорирует вызов, если следующей страницы не существует.
+    /// </remarks>
+    private async Task NextPageInternalAsync()
+    {
+        if (!CanGoNext())
+        {
+            return;
+        }
+
         PageIndex++;
-        return LoadAsync();
+        await LoadInternalAsync();
     }
 
-    private Task PrevPageAsync()
+    /// <summary>
+    /// Возвращается на предыдущую страницу и перезагружает данные.
+    /// </summary>
+    /// <returns>Задача, завершающаяся после чтения предыдущего диапазона.</returns>
+    /// <remarks>
+    /// Игнорирует вызов на первой странице.
+    /// </remarks>
+    private async Task PrevPageInternalAsync()
     {
-        if (PageIndex == 0) return Task.CompletedTask;
+        if (!CanGoPrevious())
+        {
+            return;
+        }
+
         PageIndex--;
-        return LoadAsync();
+        await LoadInternalAsync();
+    }
+
+    /// <summary>
+    /// Планирует обновление данных после изменения фильтров.
+    /// </summary>
+    /// <param name="resetPage">Нужно ли сбрасывать индекс страницы на начало.</param>
+    /// <remarks>
+    /// Вызов не выполняет загрузку, если она уже идет; пользователь может инициировать обновление вручную.
+    /// </remarks>
+    private void ScheduleReload(bool resetPage)
+    {
+        if (resetPage)
+        {
+            PageIndex = 0;
+        }
+
+        if (IsBusy)
+        {
+            _pendingReload = true;
+            return;
+        }
+
+        _ = _loadCommand.ExecuteAsync(null);
     }
 }


### PR DESCRIPTION
## Summary
- expose the filter, pagination, and refresh members required by the brand changes page bindings
- orchestrate brand audit loading with pending reload support and localized page info text

## Testing
- dotnet build *(fails: dotnet missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68fb1aae26f0832894a60a6ee51f2f85